### PR TITLE
feat: disable data-node check for the blockexplorer when no data-node endpoint is provided

### DIFF
--- a/cmd/blockexplorer.go
+++ b/cmd/blockexplorer.go
@@ -39,14 +39,15 @@ func runExplorerHealthCheck(vegaHTTPPort int, coreEndpoint, dataNodeAPIEndpoint,
 	healthChecks := []checks.HealthCheckFunc{
 		checks.CheckVegaHttpOnlineWrapper(coreEndpoint),
 		checks.CompareVegaAndCurrentTime(coreEndpoint),
-		checks.CheckDataNodeHttpOnlineWrapper(coreEndpoint),
 		checks.CheckVegaBlockIncreasedWrapper(coreEndpoint, 3*time.Second),
 		checks.CheckExplorerIsOnlineWrapper(explorerEndpoint),
 		checks.CheckExplorerTransactionListIsNotEmptyWrapper(explorerEndpoint),
 	}
 
 	if dataNodeAPIEndpoint != "" {
-		healthChecks = append(healthChecks, checks.CheckDataNodeLagWrapper(dataNodeAPIEndpoint))
+		healthChecks = append(healthChecks,
+			checks.CheckDataNodeHttpOnlineWrapper(coreEndpoint),
+			checks.CheckDataNodeLagWrapper(dataNodeAPIEndpoint))
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
close vegaprotocol/devops-infra#2099 .